### PR TITLE
feat: #3 초기 페이지 파일 생성 및 라우터 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
+import PageRouter from './pages/PageRouter'
+
 function App() {
-  return <div>App!</div>
+  return (
+    <div>
+      <PageRouter />
+    </div>
+  )
 }
 
 export default App

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,7 @@
+export default function Header() {
+  return (
+    <div>
+      <h1>Organization Name / Repository Name</h1>
+    </div>
+  )
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 export default function Header() {
   return (
-    <div>
+    <header>
       <h1>Organization Name / Repository Name</h1>
-    </div>
+    </header>
   )
 }

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom'
+
+import Header from '../Header/Header'
+
+export default function Layout() {
+  return (
+    <>
+      <Header />
+      <main>
+        <Outlet />
+      </main>
+    </>
+  )
+}

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom'
+import { styled } from 'styled-components'
+
+export default function ErrorPage() {
+  return (
+    <Wrapper>
+      <h2>404 Not Found</h2>
+      <Link to="/">목록으로 이동</Link>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+`

--- a/src/pages/IssueDetailPage.tsx
+++ b/src/pages/IssueDetailPage.tsx
@@ -1,0 +1,3 @@
+export default function IssueDetailPage() {
+  return <div>{/* TODO: IssueDetail 컴포넌트*/}</div>
+}

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -1,0 +1,16 @@
+export default function IssuesPage() {
+  return (
+    <div>
+      <div>
+        <label htmlFor="repoSelect">Repositiory 선택 : </label>
+        <select id="repoSelect" name="repoSelect">
+          <option value="facebook/react">facebook / react</option>
+          <option value="wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7">
+            wanted-pre-onboarding-team-12th-7 / pre-onboarding-12th-1-7
+          </option>
+        </select>
+      </div>
+      {/* TODO: IssueList 컴포넌트 */}
+    </div>
+  )
+}

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -1,0 +1,22 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+
+import Layout from '../components/Layout/Layout'
+import IssuesPage from './IssuesPage'
+import IssueDetailPage from './IssueDetailPage'
+import ErrorPage from './ErrorPage'
+
+function Router() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route index element={<IssuesPage />} />
+          <Route element={<IssueDetailPage />} path="/issue/:number" />
+        </Route>
+        <Route element={<ErrorPage />} path="*" />
+      </Routes>
+    </BrowserRouter>
+  )
+}
+
+export default Router


### PR DESCRIPTION
# Description

페이지와 레이아웃, 라우터를 추가했습니다.

## Changes

### 라우터

```js
return (
  <BrowserRouter>
    <Routes>
      <Route element={<Layout />}>
        <Route index element={<IssuesPage />} />
        <Route element={<IssueDetailPage />} path="/issue/:number" />
      </Route>
      <Route element={<ErrorPage />} path="*" />
    </Routes>
  </BrowserRouter>
)
```

- `IssuesPage`와 `IssueDetailPage`는 레이아웃으로 감싸 헤더를 포함했습니다.
- `IssueDetailPage`의 path prams는 깃허브와 동일하게 issue number로 지정했습니다.

### 레이아웃

```js
export default function Layout() {
  return (
    <>
      <Header />
      <main>
        <Outlet />
      </main>
    </>
  )
}
```

### 페이지
- IssuesPage

![issues](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/97281800/2f2a7bc1-2161-4fb4-9bc2-fc1d452811f0)

`<select />` 의 `<option />`으로 react와 팀 레포 추가했습니다.

- IssueDetailPage

![issue detail](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/97281800/10bfc59e-09a1-4b3e-af63-158078ec43fc)

- ErrorPage

![에러](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/97281800/c12b451a-9393-4411-8077-89988cdbe733)

누락된 작업이 있다면 말씀해주세요!