### PR TITLE
feat: #6 IssuesPage 기본 기능, Loading/Error 처리, owner/repo input data로 조회 추가 기능 작업

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
+import { IssuesProvider } from './pages/IssuesPage'
 import PageRouter from './pages/PageRouter'
 
 function App() {
   return (
     <div>
-      <PageRouter />
+      <IssuesProvider>
+        <PageRouter />
+      </IssuesProvider>
     </div>
   )
 }

--- a/src/apis/issue.ts
+++ b/src/apis/issue.ts
@@ -16,8 +16,8 @@ export interface UserDTO {
 
 export const ISSUES_PER_PAGE = 20
 
-export const getIssuesRequest = async (pageNo: number) => {
-  const { data } = await Instance.get<IssueDTO[]>(`/repos/facebook/react/issues`, {
+export const getIssuesRequest = async (owner: string, repo: string, pageNo: number) => {
+  const { status, data } = await Instance.get(`/repos/${owner}/${repo}/issues`, {
     params: {
       state: 'open',
       sort: 'comments',
@@ -26,7 +26,7 @@ export const getIssuesRequest = async (pageNo: number) => {
     },
   })
 
-  return data
+  return { status, data }
 }
 
 export const getIssueDetailRequest = async (issueNo: number) => {

--- a/src/components/Issues/IssueList.tsx
+++ b/src/components/Issues/IssueList.tsx
@@ -1,0 +1,44 @@
+import { styled } from 'styled-components'
+import { IssueDTO } from '../../apis/issue'
+import { useFormContext } from '../../pages/IssuesPage'
+
+function IssueList() {
+  const { issueList } = useFormContext()
+
+  return (
+    <>
+      {issueList?.map((issue: IssueDTO, idx: number) => (
+        <div key={idx}>
+          <IssuesWrapper>
+            <div>
+              <span>Number: </span>
+              {issue.number}
+            </div>
+            <div>
+              <span>Title: </span>
+              {issue.title}
+            </div>
+            <div>
+              <span>User: </span>
+              {issue.user.login}
+            </div>
+            <div>
+              <span>Created date: </span>
+              {issue.created_at}
+            </div>
+            <div>
+              <span>Comments count: </span>
+              {issue.comments}
+            </div>
+          </IssuesWrapper>
+        </div>
+      ))}
+    </>
+  )
+}
+
+const IssuesWrapper = styled.div`
+  margin: 20px 0;
+`
+
+export default IssueList

--- a/src/components/Issues/IssueList.tsx
+++ b/src/components/Issues/IssueList.tsx
@@ -3,7 +3,10 @@ import { IssueDTO } from '../../apis/issue'
 import { useFormContext } from '../../pages/IssuesPage'
 
 function IssueList() {
-  const { issueList } = useFormContext()
+  const { issueList, isAdvView, handleAdvClick } = useFormContext()
+  const ADV_IMG_SRC =
+    'https://image.wanted.co.kr/optimize?src=https%3A%2F%2Fstatic.wanted.co.kr%2Fimages%2Fuserweb%2Flogo_wanted_black.png&w=110&q=100'
+  const ADV_IMG_ALT = 'wanted_banner'
 
   return (
     <>
@@ -31,6 +34,9 @@ function IssueList() {
               {issue.comments}
             </div>
           </IssuesWrapper>
+          {isAdvView(idx) && (
+            <AdvImage alt={ADV_IMG_ALT} src={ADV_IMG_SRC} onClick={handleAdvClick} />
+          )}
         </div>
       ))}
     </>
@@ -39,6 +45,10 @@ function IssueList() {
 
 const IssuesWrapper = styled.div`
   margin: 20px 0;
+`
+
+const AdvImage = styled.img`
+  cursor: pointer;
 `
 
 export default IssueList

--- a/src/components/Issues/IssueList.tsx
+++ b/src/components/Issues/IssueList.tsx
@@ -23,7 +23,7 @@ function IssueList() {
             </div>
             <div>
               <span>User: </span>
-              {issue.user.login}
+              {issue?.user?.login}
             </div>
             <div>
               <span>Created date: </span>

--- a/src/components/Issues/IssueListError.tsx
+++ b/src/components/Issues/IssueListError.tsx
@@ -1,0 +1,11 @@
+import { styled } from 'styled-components'
+
+function IssueListError() {
+  return <Wrapper>Issue List Get Error!</Wrapper>
+}
+
+const Wrapper = styled.div`
+  margin: 20px 0;
+`
+
+export default IssueListError

--- a/src/components/Issues/Loading.tsx
+++ b/src/components/Issues/Loading.tsx
@@ -1,0 +1,11 @@
+import { styled } from 'styled-components'
+
+function Loading() {
+  return <Wrapper>Loading.....</Wrapper>
+}
+
+const Wrapper = styled.div`
+  margin: 20px 0;
+`
+
+export default Loading

--- a/src/components/Issues/Select.tsx
+++ b/src/components/Issues/Select.tsx
@@ -1,0 +1,28 @@
+import { styled } from 'styled-components'
+import { useFormContext } from '../../pages/IssuesPage'
+
+function Select() {
+  const { getIssuesApiCall, owner, setOwner, repo, setRepo } = useFormContext()
+
+  return (
+    <Wrapper>
+      <div>
+        <span>owner: </span>
+        <input type="text" value={owner} onChange={(e) => setOwner(e.target.value)} />
+      </div>
+      <div>
+        <span>repo: </span>
+        <input type="text" value={repo} onChange={(e) => setRepo(e.target.value)} />
+      </div>
+      <button type="button" onClick={getIssuesApiCall}>
+        조회
+      </button>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.form`
+  margin: 20px 0;
+`
+
+export default Select

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { IssueDTO, getIssuesRequest } from '../apis/issue'
+
+const useIssue = () => {
+  const [owner, setOwner] = useState<string>('facebook')
+  const [repo, setRepo] = useState<string>('react')
+  const [issueList, setIssueList] = useState<IssueDTO[] | undefined>()
+  const [isError, setIsError] = useState<boolean>(false)
+
+  const getIssuesApiCall = async () => {
+    try {
+      setIsError(false)
+      const res = await getIssuesRequest(owner, repo, 1)
+      if (res.status === 200) {
+        return setIssueList(res.data)
+      }
+      throw Error
+    } catch (err) {
+      setIsError(true)
+      console.error(err)
+      return
+    }
+  }
+
+  return {
+    owner,
+    setOwner,
+    repo,
+    setRepo,
+    issueList,
+    setIssueList,
+    isError,
+    setIsError,
+    getIssuesApiCall,
+  }
+}
+
+export default useIssue

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -4,18 +4,22 @@ import { IssueDTO, getIssuesRequest } from '../apis/issue'
 const useIssue = () => {
   const [owner, setOwner] = useState<string>('facebook')
   const [repo, setRepo] = useState<string>('react')
-  const [issueList, setIssueList] = useState<IssueDTO[] | undefined>()
+  const [issueList, setIssueList] = useState<IssueDTO[]>([])
   const [isError, setIsError] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [pageNum, setPageNum] = useState<number>(1)
+  const [isPageEnd, setIsPageEnd] = useState(false)
 
   const getIssuesApiCall = async () => {
     try {
       setIsError(false)
       setIsLoading(true)
-      const res = await getIssuesRequest(owner, repo, 1)
+      const res = await getIssuesRequest(owner, repo, pageNum)
       if (res.status === 200) {
         setIsLoading(false)
-        setIssueList(res.data)
+        setIssueList([...issueList, ...res.data])
+        setIsPageEnd(res.data.length < 30 ? true : false)
+        setPageNum(pageNum + 1)
         return
       }
       throw Error
@@ -49,6 +53,7 @@ const useIssue = () => {
     setIsError,
     isLoading,
     setIsLoading,
+    isPageEnd,
     getIssuesApiCall,
     isAdvView,
     handleAdvClick,

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -17,7 +17,8 @@ const useIssue = () => {
       const res = await getIssuesRequest(owner, repo, pageNum)
       if (res.status === 200) {
         setIsLoading(false)
-        setIssueList([...issueList, ...res.data])
+        // FIXME: 다른 owner, repo를 조회할 때는 기존 배열에 추가하면 안 됨
+        setIssueList(res.data)
         setIsPageEnd(res.data.length < 30 ? true : false)
         setPageNum(pageNum + 1)
         return

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -22,6 +22,16 @@ const useIssue = () => {
     }
   }
 
+  const isAdvView = (idx: number) => {
+    return (idx + 1) % 5 === 0
+  }
+
+  const handleAdvClick = () => {
+    const ADV_LINK_URL = 'https://www.wanted.co.kr/'
+    window.open(ADV_LINK_URL)
+    return
+  }
+
   return {
     owner,
     setOwner,
@@ -32,6 +42,8 @@ const useIssue = () => {
     isError,
     setIsError,
     getIssuesApiCall,
+    isAdvView,
+    handleAdvClick,
   }
 }
 

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -6,19 +6,25 @@ const useIssue = () => {
   const [repo, setRepo] = useState<string>('react')
   const [issueList, setIssueList] = useState<IssueDTO[] | undefined>()
   const [isError, setIsError] = useState<boolean>(false)
+  const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const getIssuesApiCall = async () => {
     try {
       setIsError(false)
+      setIsLoading(true)
       const res = await getIssuesRequest(owner, repo, 1)
       if (res.status === 200) {
-        return setIssueList(res.data)
+        setIsLoading(false)
+        setIssueList(res.data)
+        return
       }
       throw Error
     } catch (err) {
       setIsError(true)
       console.error(err)
       return
+    } finally {
+      setIsLoading(false)
     }
   }
 
@@ -41,6 +47,8 @@ const useIssue = () => {
     setIssueList,
     isError,
     setIsError,
+    isLoading,
+    setIsLoading,
     getIssuesApiCall,
     isAdvView,
     handleAdvClick,

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -4,6 +4,8 @@ import useIssue from '../hooks/useIssue'
 import { createContext } from 'react'
 import { IssueDTO } from '../apis/issue'
 import IssueList from '../components/Issues/IssueList'
+import Select from '../components/Issues/Select'
+import IssueListError from '../components/Issues/IssueListError'
 export interface IssuesContextType {
   owner: string
   setOwner: React.Dispatch<React.SetStateAction<string>>
@@ -34,7 +36,7 @@ export const useFormContext = () => {
 }
 
 export default function IssuesPage() {
-  const { getIssuesApiCall } = useFormContext()
+  const { getIssuesApiCall, isError } = useFormContext()
 
   useEffect(() => {
     getIssuesApiCall()
@@ -51,7 +53,8 @@ export default function IssuesPage() {
           </option>
         </select>
       </div>
-      <IssueList />
+      <Select />
+      {isError ? <IssueListError /> : <IssueList />}
     </Wrapper>
   )
 }

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -1,6 +1,45 @@
+import { PropsWithChildren, useContext, useEffect } from 'react'
+import { styled } from 'styled-components'
+import useIssue from '../hooks/useIssue'
+import { createContext } from 'react'
+import { IssueDTO } from '../apis/issue'
+import IssueList from '../components/Issues/IssueList'
+export interface IssuesContextType {
+  owner: string
+  setOwner: React.Dispatch<React.SetStateAction<string>>
+  repo: string
+  setRepo: React.Dispatch<React.SetStateAction<string>>
+  issueList: IssueDTO[] | undefined
+  setIssueList: React.Dispatch<React.SetStateAction<IssueDTO[] | undefined>>
+  isError: boolean
+  setIsError: React.Dispatch<React.SetStateAction<boolean>>
+  getIssuesApiCall: () => Promise<void>
+}
+
+const IssuesContext = createContext<IssuesContextType | null>(null)
+
+export function IssuesProvider({ children }: PropsWithChildren) {
+  const issueState = useIssue()
+  return <IssuesContext.Provider value={{ ...issueState }}>{children}</IssuesContext.Provider>
+}
+
+export const useFormContext = () => {
+  const context = useContext(IssuesContext)
+  if (context === null) {
+    throw Error('FormContext is null!')
+  }
+  return context
+}
+
 export default function IssuesPage() {
+  const { getIssuesApiCall } = useFormContext()
+
+  useEffect(() => {
+    getIssuesApiCall()
+  }, [])
+
   return (
-    <div>
+    <Wrapper>
       <div>
         <label htmlFor="repoSelect">Repositiory 선택 : </label>
         <select id="repoSelect" name="repoSelect">
@@ -10,7 +49,13 @@ export default function IssuesPage() {
           </option>
         </select>
       </div>
-      {/* TODO: IssueList 컴포넌트 */}
-    </div>
+      <IssueList />
+    </Wrapper>
   )
 }
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 20px;
+`

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -14,6 +14,8 @@ export interface IssuesContextType {
   isError: boolean
   setIsError: React.Dispatch<React.SetStateAction<boolean>>
   getIssuesApiCall: () => Promise<void>
+  isAdvView: (idx: number) => boolean
+  handleAdvClick: () => void
 }
 
 const IssuesContext = createContext<IssuesContextType | null>(null)

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -6,6 +6,7 @@ import { IssueDTO } from '../apis/issue'
 import IssueList from '../components/Issues/IssueList'
 import Select from '../components/Issues/Select'
 import IssueListError from '../components/Issues/IssueListError'
+import Loading from '../components/Issues/Loading'
 export interface IssuesContextType {
   owner: string
   setOwner: React.Dispatch<React.SetStateAction<string>>
@@ -15,6 +16,8 @@ export interface IssuesContextType {
   setIssueList: React.Dispatch<React.SetStateAction<IssueDTO[] | undefined>>
   isError: boolean
   setIsError: React.Dispatch<React.SetStateAction<boolean>>
+  isLoading: boolean
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
   getIssuesApiCall: () => Promise<void>
   isAdvView: (idx: number) => boolean
   handleAdvClick: () => void
@@ -36,7 +39,7 @@ export const useFormContext = () => {
 }
 
 export default function IssuesPage() {
-  const { getIssuesApiCall, isError } = useFormContext()
+  const { getIssuesApiCall, isError, isLoading } = useFormContext()
 
   useEffect(() => {
     getIssuesApiCall()
@@ -54,7 +57,7 @@ export default function IssuesPage() {
         </select>
       </div>
       <Select />
-      {isError ? <IssueListError /> : <IssueList />}
+      {isError ? <IssueListError /> : isLoading ? <Loading /> : <IssueList />}
     </Wrapper>
   )
 }


### PR DESCRIPTION
# Description
IssuesPage 기본 기능, Loading/Error 처리, owner/repo input data로 조회 추가 기능 작업을 진행했습니다.

## Changes
### 기본 페이지 기능
![IssuesPage_기본구현](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/52682692/7ec8c32a-bead-4d4c-9bdf-71a52b63cd49)
무한스크롤 데이터 요청 시 스크롤이 상단으로 올라가는 되는 문제가 있습니다.
승록님께서 이어서 작업 해주시기로 하여 여기서 마무리 합니다.

### 타 owner, repo 조회 기능
![IssuesPage_조회구현](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/52682692/91733cce-9652-415b-8c96-74e087579706)
유저에게 입력받아 조회할 수 있도록 구현하였으나 인터섹션 옵저버 적용하면서 생긴 버그를 발견했습니다.
조회할 데이터(owner, repo)가 이전과 다르다면 기존 배열에 추가하지 않고 새 데이터만 가져와야 합니다.
FIXME 주석 달아두었습니다.
