### PR TITLE
style: #11 global style 정의 및 기본 레이아웃 스타일 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-router-dom": "^6.15.0",
         "react-scripts": "5.0.1",
         "styled-components": "^6.0.7",
+        "styled-reset": "^4.5.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
@@ -17224,6 +17225,17 @@
         "babel-plugin-styled-components": {
           "optional": true
         }
+      }
+    },
+    "node_modules/styled-reset": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.5.1.tgz",
+      "integrity": "sha512-6EvFWZRwaFRFxiPYMwmnzOe33rDkw5r9jIU0eEi49bkt6VSrvjeMp2ZOw/YFbw5SVs81llIY+5fzHtR2/VBZfQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">=4.0.0 || >=5.0.0 || >=6.0.0"
       }
     },
     "node_modules/stylehacks": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-router-dom": "^6.15.0",
     "react-scripts": "5.0.1",
     "styled-components": "^6.0.7",
+    "styled-reset": "^4.5.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,12 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <title>GitHub Issues 7팀</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,19 @@
 import { IssuesProvider } from './pages/IssuesPage'
 import PageRouter from './pages/PageRouter'
 
+import { ThemeProvider } from 'styled-components'
+import GlobalStyle from './styles/base/GlobalStyles'
+import { Theme } from './styles/base/DefaultTheme'
+
 function App() {
   return (
     <div>
-      <IssuesProvider>
-        <PageRouter />
-      </IssuesProvider>
+      <ThemeProvider theme={Theme}>
+        <IssuesProvider>
+          <GlobalStyle />
+          <PageRouter />
+        </IssuesProvider>
+      </ThemeProvider>
     </div>
   )
 }

--- a/src/components/Header/Header.styled.ts
+++ b/src/components/Header/Header.styled.ts
@@ -1,0 +1,17 @@
+import { styled } from 'styled-components'
+import { fontSizes } from '../../styles/constants/fontSize'
+import colors from '../../styles/constants/colors'
+
+export const Header = styled.header`
+  width: 100%;
+  position: sticky;
+  top: 0;
+  left: 0;
+  padding: 20px;
+  font-size: ${fontSizes.medium};
+  font-weight: bold;
+  text-align: center;
+  background-color: ${({ theme }) => theme.bgColor};
+  box-shadow: 0 0 30px rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid ${colors.border};
+`

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,7 +1,9 @@
+import * as S from './Header.styled'
+
 export default function Header() {
   return (
-    <header>
+    <S.Header>
       <h1>Organization Name / Repository Name</h1>
-    </header>
+    </S.Header>
   )
 }

--- a/src/components/Layout/Layout.styled.ts
+++ b/src/components/Layout/Layout.styled.ts
@@ -1,0 +1,8 @@
+import { styled } from 'styled-components'
+
+export const Layout = styled.div`
+  position: relative;
+`
+export const Main = styled.main`
+  padding: 20px;
+`

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -2,13 +2,15 @@ import { Outlet } from 'react-router-dom'
 
 import Header from '../Header/Header'
 
+import * as S from './Layout.styled'
+
 export default function Layout() {
   return (
-    <>
+    <S.Layout>
       <Header />
-      <main>
+      <S.Main>
         <Outlet />
-      </main>
-    </>
+      </S.Main>
+    </S.Layout>
   )
 }

--- a/src/styles/base/DefaultTheme.ts
+++ b/src/styles/base/DefaultTheme.ts
@@ -1,0 +1,8 @@
+import { DefaultTheme } from 'styled-components'
+
+import { colors } from '../constants/colors'
+
+export const Theme: DefaultTheme = {
+  textColor: colors.black,
+  bgColor: colors.white,
+}

--- a/src/styles/base/GlobalStyles.ts
+++ b/src/styles/base/GlobalStyles.ts
@@ -1,0 +1,43 @@
+import { createGlobalStyle } from 'styled-components'
+import { reset } from 'styled-reset'
+import { fontSizes } from '../constants/fontSize'
+
+const GlobalStyle = createGlobalStyle`
+${reset},
+    *,
+    *::before,
+    *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
+    html, body {
+        height: 100%;
+        font-family: 'Noto Sans KR', sans-serif;
+        font-size: ${fontSizes.default};
+        color: ${({ theme }) => theme.textColor};
+    }
+    a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+    }
+    button, 
+    input, 
+    textarea, 
+    select, 
+    option {
+        font-family: inherit;
+        color: inherit;
+        font-size: inherit;
+        border: 0;
+    }
+    button:focus, 
+    input:focus, 
+    textarea:focus, 
+    select:focus{
+        outline: none;
+    }
+`
+
+export default GlobalStyle

--- a/src/styles/constants/colors.ts
+++ b/src/styles/constants/colors.ts
@@ -1,0 +1,21 @@
+export interface Colors {
+  blue: string
+  black: string
+  red: string
+  white: string
+  gray: string
+  darkgray: string
+  border: string
+}
+
+export const colors: Colors = {
+  blue: '#3B5998',
+  black: '#0F0F0F',
+  red: '#E63946',
+  white: '#ffffff',
+  gray: '#8A8A8A',
+  darkgray: '#2F2F2F',
+  border: '#ddd',
+}
+
+export default colors

--- a/src/styles/constants/flex.ts
+++ b/src/styles/constants/flex.ts
@@ -10,8 +10,8 @@ export const flex: Flex = {
     align-items: center;
   `,
   flexBetweenCenter: `
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   `,
 }

--- a/src/styles/constants/flex.ts
+++ b/src/styles/constants/flex.ts
@@ -1,0 +1,17 @@
+export interface Flex {
+  flexCenter: string
+  flexBetweenCenter: string
+}
+
+export const flex: Flex = {
+  flexCenter: `
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  `,
+  flexBetweenCenter: `
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  `,
+}

--- a/src/styles/constants/fontSize.ts
+++ b/src/styles/constants/fontSize.ts
@@ -1,0 +1,13 @@
+export interface fontSizes {
+  default: string
+  large: string
+  medium: string
+  small: string
+}
+
+export const fontSizes = {
+  default: '16px',
+  large: '36px',
+  medium: '20px',
+  small: '12px',
+}


### PR DESCRIPTION
# Description
- reset이 포함된 GlobalStyle과 자주 사용하는 스타일 상수를 정의했습니다
- ThemeProvider의 경우, 추후 다크모드 작업시 사용 가능하도록 Color 만 정의해두었습니다. 
- 레이아웃 기본 스타일 추가했습니다
- 웹폰트 추가했습니다

## Changes
- 스타일을 모두 리셋해두어, 헤더 영역이 거슬리지 않을 정도로만 기본 레이아웃 스타일 적용했습니다.

- 적용화면
![image](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/85441226/2eeb4543-43e9-4a5a-9b5d-0802a86ab2a7)
