### PR TITLE
refactor: #8 이슈 페이지 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { IssuesProvider } from './pages/IssuesPage'
 import PageRouter from './pages/PageRouter'
 
 import { ThemeProvider } from 'styled-components'
 import GlobalStyle from './styles/base/GlobalStyles'
 import { Theme } from './styles/base/DefaultTheme'
+import { IssuesProvider } from './store/IssuesContext'
 
 function App() {
   return (

--- a/src/apis/issue.ts
+++ b/src/apis/issue.ts
@@ -17,13 +17,13 @@ export interface UserDTO {
 
 export const ISSUES_PER_PAGE = 20
 
-const getIssuesRequest = async <T>(
+const getIssuesRequest = async (
   owner: string,
   repo: string,
   pageNo: number,
   perPage = ISSUES_PER_PAGE
 ) => {
-  const { status, data } = await Instance.get(`/repos/${owner}/${repo}/issues`, {
+  const { status, data } = await Instance.get<IssueDTO[]>(`/repos/${owner}/${repo}/issues`, {
     params: {
       state: 'open',
       sort: 'comments',
@@ -32,7 +32,7 @@ const getIssuesRequest = async <T>(
     },
   })
 
-  return { status, data: data as T }
+  return { status, data }
 }
 
 const getIssueDetailRequest = async (issueNo: number) => {

--- a/src/apis/issue.ts
+++ b/src/apis/issue.ts
@@ -7,6 +7,7 @@ export interface IssueDTO {
   created_at: string
   comments: number
   user: UserDTO
+  pull_request: object
 }
 
 export interface UserDTO {
@@ -16,21 +17,31 @@ export interface UserDTO {
 
 export const ISSUES_PER_PAGE = 20
 
-export const getIssuesRequest = async (owner: string, repo: string, pageNo: number) => {
+const getIssuesRequest = async <T>(
+  owner: string,
+  repo: string,
+  pageNo: number,
+  perPage = ISSUES_PER_PAGE
+) => {
   const { status, data } = await Instance.get(`/repos/${owner}/${repo}/issues`, {
     params: {
       state: 'open',
       sort: 'comments',
-      per_page: ISSUES_PER_PAGE,
+      per_page: perPage,
       page: pageNo,
     },
   })
 
-  return { status, data }
+  return { status, data: data as T }
 }
 
-export const getIssueDetailRequest = async (issueNo: number) => {
+const getIssueDetailRequest = async (issueNo: number) => {
   const { data } = await Instance.get<IssueDTO>(`/repos/facebook/react/issues/${issueNo}`)
 
   return data
+}
+
+export const issueAPI = {
+  getIssueList: getIssuesRequest,
+  getIssueDetail: getIssueDetailRequest,
 }

--- a/src/components/Issues/ImageBanner.tsx
+++ b/src/components/Issues/ImageBanner.tsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components'
+
+interface ImageBannerProps {
+  alt: string
+  src: string
+  link: string
+}
+
+function ImageBanner({
+  alt = 'alt text',
+  src = 'image src',
+  link = 'link url of image',
+}: ImageBannerProps) {
+  return (
+    <AdvImage
+      alt={alt}
+      src={src}
+      onClick={() => {
+        window.open(link)
+      }}
+    />
+  )
+}
+
+export default ImageBanner
+
+const AdvImage = styled.img`
+  cursor: pointer;
+`

--- a/src/components/Issues/IssueList.tsx
+++ b/src/components/Issues/IssueList.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components'
 import { IssueDTO } from '../../apis/issue'
-import { useIssueListContext } from '../../pages/IssuesPage'
+import { useIssueListContext } from '../../hooks/useIssueListContext'
 
 function IssueList() {
   const { issueList, isAdvView, handleAdvClick } = useIssueListContext()

--- a/src/components/Issues/IssueList.tsx
+++ b/src/components/Issues/IssueList.tsx
@@ -1,9 +1,9 @@
 import { styled } from 'styled-components'
 import { IssueDTO } from '../../apis/issue'
-import { useFormContext } from '../../pages/IssuesPage'
+import { useIssueListContext } from '../../pages/IssuesPage'
 
 function IssueList() {
-  const { issueList, isAdvView, handleAdvClick } = useFormContext()
+  const { issueList, isAdvView, handleAdvClick } = useIssueListContext()
   const ADV_IMG_SRC =
     'https://image.wanted.co.kr/optimize?src=https%3A%2F%2Fstatic.wanted.co.kr%2Fimages%2Fuserweb%2Flogo_wanted_black.png&w=110&q=100'
   const ADV_IMG_ALT = 'wanted_banner'

--- a/src/components/Issues/IssueList.tsx
+++ b/src/components/Issues/IssueList.tsx
@@ -1,17 +1,26 @@
 import { styled } from 'styled-components'
 import { IssueDTO } from '../../apis/issue'
 import { useIssueListContext } from '../../hooks/useIssueListContext'
+import { ReactNode } from 'react'
 
-function IssueList() {
-  const { issueList, isAdvView, handleAdvClick } = useIssueListContext()
-  const ADV_IMG_SRC =
-    'https://image.wanted.co.kr/optimize?src=https%3A%2F%2Fstatic.wanted.co.kr%2Fimages%2Fuserweb%2Flogo_wanted_black.png&w=110&q=100'
-  const ADV_IMG_ALT = 'wanted_banner'
+interface IssueListProps {
+  AdElement?: ReactNode | null
+  adInterval: number
+}
+
+const isAdPosition = (idx: number, adInterval: number) => {
+  if (adInterval <= 0) throw Error('Wrong adInterval')
+  if (adInterval === 1) return true
+  return (idx + 1) % (adInterval - 1) === 0
+}
+
+function IssueList({ AdElement, adInterval }: IssueListProps) {
+  const { issueList } = useIssueListContext()
 
   return (
     <>
       {issueList?.map((issue: IssueDTO, idx: number) => (
-        <div key={idx}>
+        <div key={issue.number}>
           <IssuesWrapper>
             <div>
               <span>Number: </span>
@@ -34,9 +43,7 @@ function IssueList() {
               {issue.comments}
             </div>
           </IssuesWrapper>
-          {isAdvView(idx) && (
-            <AdvImage alt={ADV_IMG_ALT} src={ADV_IMG_SRC} onClick={handleAdvClick} />
-          )}
+          {isAdPosition(idx, adInterval) && AdElement}
         </div>
       ))}
     </>
@@ -45,10 +52,6 @@ function IssueList() {
 
 const IssuesWrapper = styled.div`
   margin: 20px 0;
-`
-
-const AdvImage = styled.img`
-  cursor: pointer;
 `
 
 export default IssueList

--- a/src/components/Issues/Select.tsx
+++ b/src/components/Issues/Select.tsx
@@ -1,8 +1,8 @@
 import { styled } from 'styled-components'
-import { useFormContext } from '../../pages/IssuesPage'
+import { useIssueListContext } from '../../pages/IssuesPage'
 
 function Select() {
-  const { getIssuesApiCall, owner, setOwner, repo, setRepo } = useFormContext()
+  const { getIssuesApiCall, owner, setOwner, repo, setRepo } = useIssueListContext()
 
   return (
     <Wrapper>

--- a/src/components/Issues/Select.tsx
+++ b/src/components/Issues/Select.tsx
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components'
-import { useIssueListContext } from '../../pages/IssuesPage'
+import { useIssueListContext } from '../../hooks/useIssueListContext'
 
 function Select() {
   const { getIssuesApiCall, owner, setOwner, repo, setRepo } = useIssueListContext()

--- a/src/components/Issues/constant.ts
+++ b/src/components/Issues/constant.ts
@@ -1,0 +1,10 @@
+const ADVERTISEMENT = {
+  ISSUE_LIST: {
+    IMG_SRC:
+      'https://image.wanted.co.kr/optimize?src=https%3A%2F%2Fstatic.wanted.co.kr%2Fimages%2Fuserweb%2Flogo_wanted_black.png&w=110&q=100',
+    IMG_ALT: 'wanted_banner',
+    LINK_URL: 'https://www.wanted.co.kr/',
+  },
+}
+
+export { ADVERTISEMENT }

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { IssueDTO, issueAPI } from '../apis/issue'
 
 const useIssue = () => {
@@ -37,6 +37,10 @@ const useIssue = () => {
       setIsLoading(false)
     }
   }
+
+  useEffect(() => {
+    getIssuesApiCall()
+  }, [])
 
   return {
     owner,

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -10,6 +10,8 @@ const useIssue = () => {
   const [pageNum, setPageNum] = useState<number>(1)
   const [isPageEnd, setIsPageEnd] = useState(false)
 
+  const filterPureIssue = (data: IssueDTO[]) => data.filter((issue) => !issue.pull_request)
+
   const getIssuesApiCall = async () => {
     try {
       setIsError(false)
@@ -18,13 +20,8 @@ const useIssue = () => {
       if (res.status === 200) {
         setIsLoading(false)
         // FIXME: 다른 owner, repo를 조회할 때는 기존 배열에 추가하면 안 됨
-        setIssueList((prev) => {
-          const pureNewIssues = res.data
-            .filter((issue) => !issue.pull_request)
-            .filter((issue) => !prev.find((prevIssue) => prevIssue.number === issue.number))
-          return prev.concat(pureNewIssues)
-        })
-        setIsPageEnd(res.data.length < 30 ? true : false)
+        setIssueList((prev) => prev.concat(filterPureIssue(res.data)))
+        setIsPageEnd(res.data.length < 30)
         setPageNum(pageNum + 1)
         return
       }

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -16,7 +16,7 @@ const useIssue = () => {
     try {
       setIsError(false)
       setIsLoading(true)
-      const res = await issueAPI.getIssueList<IssueDTO[]>(owner, repo, pageNum)
+      const res = await issueAPI.getIssueList(owner, repo, pageNum)
       if (res.status === 200) {
         setIsLoading(false)
         // FIXME: 다른 owner, repo를 조회할 때는 기존 배열에 추가하면 안 됨

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -38,16 +38,6 @@ const useIssue = () => {
     }
   }
 
-  const isAdvView = (idx: number) => {
-    return (idx + 1) % 5 === 0
-  }
-
-  const handleAdvClick = () => {
-    const ADV_LINK_URL = 'https://www.wanted.co.kr/'
-    window.open(ADV_LINK_URL)
-    return
-  }
-
   return {
     owner,
     setOwner,
@@ -61,8 +51,6 @@ const useIssue = () => {
     setIsLoading,
     isPageEnd,
     getIssuesApiCall,
-    isAdvView,
-    handleAdvClick,
   }
 }
 

--- a/src/hooks/useIssueListContext.ts
+++ b/src/hooks/useIssueListContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { IssuesContext } from '../store/IssuesContext'
+
+export const useIssueListContext = () => {
+  const context = useContext(IssuesContext)
+  if (context === null) {
+    throw Error('IssueList Context is null!')
+  }
+  return context
+}

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -11,10 +11,6 @@ import { ADVERTISEMENT } from '../components/Issues/constant'
 export default function IssuesPage() {
   const { getIssuesApiCall, isError, isLoading, issueList, isPageEnd } = useIssueListContext()
 
-  useEffect(() => {
-    getIssuesApiCall()
-  }, [])
-
   const handleObserver = useCallback(
     async ([entry]: IntersectionObserverEntry[], observer: IntersectionObserver) => {
       if (entry.isIntersecting) {
@@ -35,15 +31,6 @@ export default function IssuesPage() {
 
   return (
     <Wrapper>
-      <div>
-        <label htmlFor="repoSelect">Repositiory 선택 : </label>
-        <select id="repoSelect" name="repoSelect">
-          <option value="facebook/react">facebook / react</option>
-          <option value="wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-1-7">
-            wanted-pre-onboarding-team-12th-7 / pre-onboarding-12th-1-7
-          </option>
-        </select>
-      </div>
       <Select />
       {isError && <IssueListError />}
       <IssueList

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -1,43 +1,10 @@
-import { PropsWithChildren, useContext, useEffect, useCallback, useRef } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 import { styled } from 'styled-components'
-import useIssue from '../hooks/useIssue'
-import { createContext } from 'react'
-import { IssueDTO } from '../apis/issue'
 import IssueList from '../components/Issues/IssueList'
 import Select from '../components/Issues/Select'
 import IssueListError from '../components/Issues/IssueListError'
 import Loading from '../components/Issues/Loading'
-export interface IssuesContextType {
-  owner: string
-  setOwner: React.Dispatch<React.SetStateAction<string>>
-  repo: string
-  setRepo: React.Dispatch<React.SetStateAction<string>>
-  issueList: IssueDTO[] | undefined
-  setIssueList: React.Dispatch<React.SetStateAction<IssueDTO[]>>
-  isError: boolean
-  setIsError: React.Dispatch<React.SetStateAction<boolean>>
-  isLoading: boolean
-  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
-  isPageEnd: boolean
-  getIssuesApiCall: () => Promise<void>
-  isAdvView: (idx: number) => boolean
-  handleAdvClick: () => void
-}
-
-const IssuesContext = createContext<IssuesContextType | null>(null)
-
-export function IssuesProvider({ children }: PropsWithChildren) {
-  const issueState = useIssue()
-  return <IssuesContext.Provider value={{ ...issueState }}>{children}</IssuesContext.Provider>
-}
-
-export const useIssueListContext = () => {
-  const context = useContext(IssuesContext)
-  if (context === null) {
-    throw Error('FormContext is null!')
-  }
-  return context
-}
+import { useIssueListContext } from '../hooks/useIssueListContext'
 
 export default function IssuesPage() {
   const { getIssuesApiCall, isError, isLoading, issueList, isPageEnd } = useIssueListContext()

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -31,7 +31,7 @@ export function IssuesProvider({ children }: PropsWithChildren) {
   return <IssuesContext.Provider value={{ ...issueState }}>{children}</IssuesContext.Provider>
 }
 
-export const useFormContext = () => {
+export const useIssueListContext = () => {
   const context = useContext(IssuesContext)
   if (context === null) {
     throw Error('FormContext is null!')
@@ -40,7 +40,7 @@ export const useFormContext = () => {
 }
 
 export default function IssuesPage() {
-  const { getIssuesApiCall, isError, isLoading, issueList, isPageEnd } = useFormContext()
+  const { getIssuesApiCall, isError, isLoading, issueList, isPageEnd } = useIssueListContext()
 
   useEffect(() => {
     getIssuesApiCall()

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useCallback, useRef } from 'react'
 import { styled } from 'styled-components'
-import IssueList from '../components/Issues/IssueList'
 import Select from '../components/Issues/Select'
 import IssueListError from '../components/Issues/IssueListError'
 import Loading from '../components/Issues/Loading'
 import { useIssueListContext } from '../hooks/useIssueListContext'
+import ImageBanner from '../components/Issues/ImageBanner'
+import IssueList from '../components/Issues/IssueList'
+import { ADVERTISEMENT } from '../components/Issues/constant'
 
 export default function IssuesPage() {
   const { getIssuesApiCall, isError, isLoading, issueList, isPageEnd } = useIssueListContext()
@@ -43,7 +45,18 @@ export default function IssuesPage() {
         </select>
       </div>
       <Select />
-      {isError ? <IssueListError /> : isLoading ? <Loading /> : <IssueList />}
+      {isError && <IssueListError />}
+      <IssueList
+        AdElement={
+          <ImageBanner
+            alt={ADVERTISEMENT.ISSUE_LIST.IMG_ALT}
+            link={ADVERTISEMENT.ISSUE_LIST.LINK_URL}
+            src={ADVERTISEMENT.ISSUE_LIST.IMG_SRC}
+          />
+        }
+        adInterval={5}
+      />
+      {isLoading && <Loading />}
       {isPageEnd && <div ref={loadMoreRef}>observer</div>}
     </Wrapper>
   )

--- a/src/store/IssuesContext.tsx
+++ b/src/store/IssuesContext.tsx
@@ -15,8 +15,6 @@ export interface IssuesContextType {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
   isPageEnd: boolean
   getIssuesApiCall: () => Promise<void>
-  isAdvView: (idx: number) => boolean
-  handleAdvClick: () => void
 }
 
 export const IssuesContext = createContext<IssuesContextType | null>(null)

--- a/src/store/IssuesContext.tsx
+++ b/src/store/IssuesContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, PropsWithChildren } from 'react'
+import { IssueDTO } from '../apis/issue'
+import useIssue from '../hooks/useIssue'
+
+export interface IssuesContextType {
+  owner: string
+  setOwner: React.Dispatch<React.SetStateAction<string>>
+  repo: string
+  setRepo: React.Dispatch<React.SetStateAction<string>>
+  issueList: IssueDTO[] | undefined
+  setIssueList: React.Dispatch<React.SetStateAction<IssueDTO[]>>
+  isError: boolean
+  setIsError: React.Dispatch<React.SetStateAction<boolean>>
+  isLoading: boolean
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
+  isPageEnd: boolean
+  getIssuesApiCall: () => Promise<void>
+  isAdvView: (idx: number) => boolean
+  handleAdvClick: () => void
+}
+
+export const IssuesContext = createContext<IssuesContextType | null>(null)
+
+export function IssuesProvider({ children }: PropsWithChildren) {
+  const issueState = useIssue()
+  return <IssuesContext.Provider value={{ ...issueState }}>{children}</IssuesContext.Provider>
+}


### PR DESCRIPTION
# Description
- [x] IssuesPage 에서 Context API 분리하기
- [ ] types 분리하기
- [x] Constants 분리하기
- [x] Github [공식문서](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues)에 따라, pull_request 거르기는 로직 추가하기
- [x] 이전 데이터와 비교하여 페이지에 중복되는 데이터가 없게 필터로직 추가
- [x] 네이밍 개선
- [x] 이슈 리스트 관심사 분리

## Summary 
![refactorissuepage](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/44149596/dc7c63d1-b4f7-4373-b4d5-858ef0154fed)
