### PR TITLE
config: #29 sort-import ESLint 룰 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,7 @@ module.exports = {
         namedComponents: 'function-declaration',
       },
     ],
-    'react-hooks/exhaustive-deps': 'warn',
+    'react-hooks/exhaustive-deps': 'off',
     'no-multiple-empty-lines': 'error',
     'no-console': ['error', { allow: ['warn', 'error', 'info'] }], // console.log() 금지
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,11 @@ module.exports = {
     react: {
       version: 'detect',
     },
+    'import/resolver': {
+      typescript: {},
+    },
   },
+
   env: {
     browser: true,
     es2021: true,
@@ -26,7 +30,7 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ['@typescript-eslint', 'react'],
+  plugins: ['@typescript-eslint', 'react', 'import'],
   rules: {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-uses-react': 'off',
@@ -53,5 +57,22 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'off',
     'no-multiple-empty-lines': 'error',
     'no-console': ['error', { allow: ['warn', 'error', 'info'] }], // console.log() 금지
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', ['parent', 'sibling'], 'type', 'unknown'],
+        pathGroups: [
+          {
+            pattern: '{.,..}/**/*.styled',
+            group: 'object',
+          },
+        ],
+        'newlines-between': 'always',
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
+      },
+    ],
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
       "devDependencies": {
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
+        "eslint-import-resolver-typescript": "^3.6.0",
+        "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "husky": "^8.0.3",
@@ -7537,6 +7539,31 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.0.tgz",
+      "integrity": "sha512-QTHR9ddNnn35RTxlaEnx2gCxqFlF2SEN0SE2d17SqwyM7YOSI2GHWRYp5BiRkObTUNYPupC/3Fq2a0PpT+EKpg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
+      }
+    },
     "node_modules/eslint-module-utils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
@@ -8819,6 +8846,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
+      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -16966,6 +17005,15 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve-url-loader": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
   "devDependencies": {
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.0",
+    "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import PageRouter from './pages/PageRouter'
-
 import { ThemeProvider } from 'styled-components'
-import GlobalStyle from './styles/base/GlobalStyles'
-import { Theme } from './styles/base/DefaultTheme'
+
+import PageRouter from './pages/PageRouter'
 import { IssuesProvider } from './store/IssuesContext'
+import { Theme } from './styles/base/DefaultTheme'
+import GlobalStyle from './styles/base/GlobalStyles'
 
 function App() {
   return (

--- a/src/components/Error/Error.styled.ts
+++ b/src/components/Error/Error.styled.ts
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom'
 import { styled } from 'styled-components'
 
-import { flex } from '../../styles/constants/flex'
 import { colors } from './../../styles/constants/colors'
+import { flex } from '../../styles/constants/flex'
 import { fontSizes } from '../../styles/constants/fontSize'
 
 export const Wrapper = styled.div`

--- a/src/components/Header/Header.styled.ts
+++ b/src/components/Header/Header.styled.ts
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components'
-import { fontSizes } from '../../styles/constants/fontSize'
+
 import colors from '../../styles/constants/colors'
+import { fontSizes } from '../../styles/constants/fontSize'
 
 export const Header = styled.header`
   width: 100%;

--- a/src/components/IssueDetail/IssueBody.tsx
+++ b/src/components/IssueDetail/IssueBody.tsx
@@ -3,6 +3,7 @@ import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
 
 import { IssueDetailType } from './type'
+
 import * as S from './IssueDetail.styled'
 
 function IssueBody({ item }: IssueDetailType) {

--- a/src/components/Issues/IssueList.tsx
+++ b/src/components/Issues/IssueList.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { IssueDTO } from '../../apis/issue'
 import { useIssueListContext } from '../../hooks/useIssueListContext'
+
 import * as S from './Issues.styled'
 
 interface IssueListProps {

--- a/src/components/Issues/Issues.styled.ts
+++ b/src/components/Issues/Issues.styled.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+
 import { colors } from './../../styles/constants/colors'
 import { flex } from '../../styles/constants/flex'
 import { fontSizes } from '../../styles/constants/fontSize'

--- a/src/hooks/useIssue.tsx
+++ b/src/hooks/useIssue.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+
 import { ISSUES_PER_PAGE, IssueDTO, issueAPI } from '../apis/issue'
 
 const useIssue = () => {

--- a/src/hooks/useIssueListContext.ts
+++ b/src/hooks/useIssueListContext.ts
@@ -1,4 +1,5 @@
 import { useContext } from 'react'
+
 import { IssuesContext } from '../store/IssuesContext'
 
 export const useIssueListContext = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+
 import App from './App'
 import reportWebVitals from './reportWebVitals'
 

--- a/src/pages/IssueDetailPage.tsx
+++ b/src/pages/IssueDetailPage.tsx
@@ -3,11 +3,11 @@ import { useParams } from 'react-router-dom'
 import { styled } from 'styled-components'
 
 import { IssueDTO, issueAPI } from '../apis/issue'
-import { useIssueListContext } from '../hooks/useIssueListContext'
-import { flex } from '../styles/constants/flex'
+import IssueBody from '../components/IssueDetail/IssueBody'
 import IssueTitle from '../components/IssueDetail/IssueTitle'
 import Loading from '../components/Issues/Loading'
-import IssueBody from '../components/IssueDetail/IssueBody'
+import { useIssueListContext } from '../hooks/useIssueListContext'
+import { flex } from '../styles/constants/flex'
 
 export default function IssueDetailPage() {
   const { owner, repo } = useIssueListContext()

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useCallback, useRef } from 'react'
-import Select from '../components/Issues/Select'
-import IssueListError from '../components/Issues/IssueListError'
-import Loading from '../components/Issues/Loading'
-import { useIssueListContext } from '../hooks/useIssueListContext'
+
+import { ADVERTISEMENT } from '../components/Issues/constant'
 import ImageBanner from '../components/Issues/ImageBanner'
 import IssueList from '../components/Issues/IssueList'
-import { ADVERTISEMENT } from '../components/Issues/constant'
+import IssueListError from '../components/Issues/IssueListError'
+import Loading from '../components/Issues/Loading'
+import Select from '../components/Issues/Select'
+import { useIssueListContext } from '../hooks/useIssueListContext'
 
 import * as S from '../components/Issues/Issues.styled'
 

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -1,9 +1,9 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
-import Layout from '../components/Layout/Layout'
-import IssuesPage from './IssuesPage'
-import IssueDetailPage from './IssueDetailPage'
 import ErrorPage from './ErrorPage'
+import IssueDetailPage from './IssueDetailPage'
+import IssuesPage from './IssuesPage'
+import Layout from '../components/Layout/Layout'
 
 function Router() {
   return (

--- a/src/store/IssuesContext.tsx
+++ b/src/store/IssuesContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, PropsWithChildren } from 'react'
+
 import { IssueDTO } from '../apis/issue'
 import useIssue from '../hooks/useIssue'
 

--- a/src/styles/base/GlobalStyles.ts
+++ b/src/styles/base/GlobalStyles.ts
@@ -1,5 +1,6 @@
 import { createGlobalStyle } from 'styled-components'
 import { reset } from 'styled-reset'
+
 import { fontSizes } from '../constants/fontSize'
 
 const GlobalStyle = createGlobalStyle`


### PR DESCRIPTION
# Description

import sort 룰 추가했습니다.

# Changes

```js
'import/order': [
  'error',
  {
    groups: [
      'builtin',       // 내장 모듈 (예: fs, path)
      'external',      // 외부 패키지 (npm 등으로 설치한 모듈)
      'internal',      // 내부 프로젝트 모듈 (프로젝트 내부에서 사용하는 모듈)
      ['parent', 'sibling'], // 상위 폴더의 모듈과 같은 폴더 내 모듈 (상대 경로)
      'type',          // .d.ts (타입 정의) 모듈
      'unknown',       // 그 외 알 수 없는 모듈
    ],
    pathGroups: [
      {
        pattern: '{.,..}/**/*.styled', // 현재 폴더와 상위 폴더 내의 모든 .styled로 끝나는 모듈
        group: 'object',               // 해당 모듈들을 'object' 그룹으로 배치
      },
    ],
    'newlines-between': 'always',   // 각 그룹 사이에 항상 개행 추가
    alphabetize: {
      order: 'asc',                  // 모듈 이름 알파벳순 정렬
      caseInsensitive: true,         // 대소문자 구분하지 않고 정렬
    },
  },
],
```

- 추가적인 규칙은 https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/order.md 에서 확인할 수 있습니다!

- 적용 예시
![1](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/97281800/29b7fe38-3df1-436b-888a-74185697912c)
![2](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/97281800/e5cbc9dc-f6cb-4ee4-b8c5-7f87fd5ecb81)

- 그 외에 리액트 훅에서 의존성 배열 warning -> off로 변경했습니다!