### PR TITLE
refactor: #23, #25 ThemeProvider 타입추론 적용, 상수 추가 후 적용

### DIFF
--- a/src/components/Error/Error.styled.ts
+++ b/src/components/Error/Error.styled.ts
@@ -1,28 +1,24 @@
 import { Link } from 'react-router-dom'
 import { styled } from 'styled-components'
 
-import { colors } from './../../styles/constants/colors'
-import { flex } from '../../styles/constants/flex'
-import { fontSizes } from '../../styles/constants/fontSize'
-
 export const Wrapper = styled.div`
-  ${flex.flexColumnCenter}
+  ${({ theme }) => theme.flex.flexColumnCenter}
   height: 100vh;
   padding: 20px;
   gap: 50px;
 `
 export const Title = styled.h2`
-  font-size: ${fontSizes.large};
+  font-size: ${({ theme }) => theme.fontSizes.large};
   font-weight: 700;
-  color: ${colors.red};
+  color: ${({ theme }) => theme.colors.red};
 `
 export const Button = styled(Link)`
-  ${flex.flexCenter}
+  ${({ theme }) => theme.flex.flexCenter}
   width: 260px;
   height: 50px;
   border-radius: 4px;
-  background-color: ${colors.red};
-  color: ${colors.white};
+  background-color: ${({ theme }) => theme.colors.red};
+  color: ${({ theme }) => theme.colors.white};
   font-weight: 500;
   transition: 200ms;
 

--- a/src/components/Header/Header.styled.ts
+++ b/src/components/Header/Header.styled.ts
@@ -1,18 +1,15 @@
 import { styled } from 'styled-components'
 
-import colors from '../../styles/constants/colors'
-import { fontSizes } from '../../styles/constants/fontSize'
-
 export const Header = styled.header`
   width: 100%;
   position: sticky;
   top: 0;
   left: 0;
   padding: 20px;
-  font-size: ${fontSizes.medium};
+  font-size: ${({ theme }) => theme.fontSizes.medium};
   font-weight: bold;
   text-align: center;
-  background-color: ${({ theme }) => theme.boxColor};
+  background-color: ${({ theme }) => theme.colors.boxColor};
   box-shadow: 0 0 30px rgba(0, 0, 0, 0.1);
-  border-bottom: 1px solid ${colors.border};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
 `

--- a/src/components/Issues/Issues.styled.ts
+++ b/src/components/Issues/Issues.styled.ts
@@ -1,21 +1,16 @@
 import styled from 'styled-components'
 
-import { colors } from './../../styles/constants/colors'
-import { flex } from '../../styles/constants/flex'
-import { fontSizes } from '../../styles/constants/fontSize'
-
 export const Wrapper = styled.div``
-
 export const SelectWrapper = styled.form`
-  ${flex.flexColumnCenter}
+  ${({ theme }) => theme.flex.flexColumnCenter};
   gap: 20px;
   padding: 20px;
-  background-color: ${({ theme }) => theme.boxColor};
+  background-color: ${({ theme }) => theme.colors.boxColor};
   border-radius: 10px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 `
 export const FromRow = styled.div`
-  ${flex.flexBetweenCenter}
+  ${({ theme }) => theme.flex.flexBetweenCenter}
   width: 100%;
 `
 export const FormTitle = styled.div`
@@ -26,23 +21,23 @@ export const FormTitle = styled.div`
 export const FormInput = styled.input`
   width: 100%;
   height: 40px;
-  border: 1px solid ${colors.border};
+  border: 1px solid ${({ theme }) => theme.colors.border};
   padding: 0 14px;
   border-radius: 4px;
 `
 export const FormButton = styled.button`
   width: 100%;
   height: 40px;
-  background-color: ${({ theme }) => theme.primaryButtonColor};
+  background-color: ${({ theme }) => theme.colors.primaryButtonColor};
   border-radius: 4px;
-  color: ${({ theme }) => theme.primaryButtonTextColor};
+  color: ${({ theme }) => theme.colors.primaryButtonTextColor};
   font-weight: 500;
   cursor: pointer;
 `
 export const IssueListWrapper = styled.div`
   margin-top: 30px;
   padding: 0 20px;
-  background-color: ${({ theme }) => theme.boxColor};
+  background-color: ${({ theme }) => theme.colors.boxColor};
   border-radius: 10px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   cursor: pointer;
@@ -52,16 +47,16 @@ export const IssueListItem = styled.div`
   flex-direction: column;
   gap: 10px;
   padding: 20px 0;
-  border-bottom: 1px solid ${colors.border};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
 `
 export const IssueListItemNumber = styled.div`
   width: fit-content;
   padding: 4px 10px;
-  background-color: ${({ theme }) => theme.primaryButtonColor};
+  background-color: ${({ theme }) => theme.colors.primaryButtonColor};
   border-radius: 4px;
-  color: ${({ theme }) => theme.primaryButtonTextColor};
+  color: ${({ theme }) => theme.colors.primaryButtonTextColor};
   font-weight: 700;
-  font-size: ${fontSizes.small};
+  font-size: ${({ theme }) => theme.fontSizes.small};
 `
 export const IssueListItemTitle = styled.div`
   font-weight: 500;
@@ -70,16 +65,16 @@ export const IssueListItemUserInfo = styled.div`
   display: flex;
   flex-direction: column;
   gap: 6px;
-  font-size: ${fontSizes.small};
-  color: ${({ theme }) => theme.subTextColor};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  color: ${({ theme }) => theme.colors.subTextColor};
 `
 export const IssueListAdBox = styled.div`
-  ${flex.flexCenter}
+  ${({ theme }) => theme.flex.flexCenter};
   padding: 20px;
-  border-bottom: 1px solid ${colors.border};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
 `
 export const loadingWrapper = styled.div`
-  ${flex.flexCenter}
+  ${({ theme }) => theme.flex.flexCenter};
   padding: 20px;
   font-weight: bold;
 `

--- a/src/styles/base/DefaultTheme.ts
+++ b/src/styles/base/DefaultTheme.ts
@@ -1,12 +1,11 @@
 import { DefaultTheme } from 'styled-components'
 
 import { colors } from '../constants/colors'
+import { flex } from '../constants/flex'
+import { fontSizes } from '../constants/fontSize'
 
 export const Theme: DefaultTheme = {
-  textColor: colors.black,
-  subTextColor: colors.darkgray,
-  bgColor: colors.lightGray,
-  boxColor: colors.opacityWhite,
-  primaryButtonColor: colors.black,
-  primaryButtonTextColor: colors.white,
+  colors,
+  fontSizes,
+  flex,
 }

--- a/src/styles/base/GlobalStyles.ts
+++ b/src/styles/base/GlobalStyles.ts
@@ -1,8 +1,6 @@
 import { createGlobalStyle } from 'styled-components'
 import { reset } from 'styled-reset'
 
-import { fontSizes } from '../constants/fontSize'
-
 const GlobalStyle = createGlobalStyle`
 ${reset},
     *,
@@ -15,11 +13,11 @@ ${reset},
     html, body {
         height: 100%;
         font-family: 'Noto Sans KR', sans-serif;
-        font-size: ${fontSizes.default};
-        color: ${({ theme }) => theme.textColor};
+        font-size: ${({ theme }) => theme.fontSizes.default};
+        color: ${({ theme }) => theme.colors.textColor};
     }
     body {
-        background: ${({ theme }) => theme.bgColor};
+        background: ${({ theme }) => theme.colors.bgColor};
     }
     a {
         color: inherit;

--- a/src/styles/base/styled.d.ts
+++ b/src/styles/base/styled.d.ts
@@ -1,7 +1,7 @@
 import 'styled-components'
-import { FlexType } from '../constants/flex'
-import { ColorType } from '../constants/colors'
 import { FontSizeType } from './../constants/fontSize'
+import { ColorType } from '../constants/colors'
+import { FlexType } from '../constants/flex'
 
 declare module 'styled-components' {
   interface DefaultTheme extends ExtendedTheme {

--- a/src/styles/base/styled.d.ts
+++ b/src/styles/base/styled.d.ts
@@ -1,12 +1,12 @@
 import 'styled-components'
 import { FlexType } from '../constants/flex'
 import { ColorType } from '../constants/colors'
-import { fontSizeType } from './../constants/fontSize'
+import { FontSizeType } from './../constants/fontSize'
 
 declare module 'styled-components' {
   interface DefaultTheme extends ExtendedTheme {
     colors: ColorType
     flex: FlexType
-    fontSizes: fontSizeType
+    fontSizes: FontSizeType
   }
 }

--- a/src/styles/base/styled.d.ts
+++ b/src/styles/base/styled.d.ts
@@ -1,0 +1,12 @@
+import 'styled-components'
+import { FlexType } from '../constants/flex'
+import { ColorType } from '../constants/colors'
+import { fontSizeType } from './../constants/fontSize'
+
+declare module 'styled-components' {
+  interface DefaultTheme extends ExtendedTheme {
+    colors: ColorType
+    flex: FlexType
+    fontSizes: fontSizeType
+  }
+}

--- a/src/styles/constants/colors.ts
+++ b/src/styles/constants/colors.ts
@@ -1,27 +1,29 @@
-export interface Colors {
+export interface ColorType {
+  textColor: string
+  subTextColor: string
+  border: string
+  boxColor: string
+  dimmed: string
+  bgColor: string
   blue: string
-  black: string
   red: string
   white: string
-  opacityWhite: string
-  gray: string
-  lightGray: string
-  darkgray: string
-  border: string
-  dimmed: string
+  primaryButtonColor: string
+  primaryButtonTextColor: string
 }
 
-export const colors: Colors = {
+export const colors: ColorType = {
+  textColor: '#0F0F0F',
+  subTextColor: '#2F2F2F',
+  border: '#ddd',
+  boxColor: 'rgba(255,255,255,0.8)',
+  dimmed: 'rgba(0,0,0,0.9)',
+  bgColor: '#efefef',
   blue: '#3B5998',
-  black: '#0F0F0F',
   red: '#E63946',
   white: '#ffffff',
-  opacityWhite: 'rgba(255,255,255,0.8)',
-  gray: '#8A8A8A',
-  lightGray: '#efefef',
-  darkgray: '#2F2F2F',
-  border: '#ddd',
-  dimmed: 'rgba(0,0,0,0.9)',
+  primaryButtonColor: '#0F0F0F',
+  primaryButtonTextColor: '#fff',
 }
 
 export default colors

--- a/src/styles/constants/flex.ts
+++ b/src/styles/constants/flex.ts
@@ -1,11 +1,11 @@
-export interface Flex {
+export interface FlexType {
   flexCenter: string
   flexStart: string
   flexBetweenCenter: string
   flexColumnCenter: string
 }
 
-export const flex: Flex = {
+export const flex: FlexType = {
   flexCenter: `
     display: flex;
     justify-content: center;

--- a/src/styles/constants/fontSize.ts
+++ b/src/styles/constants/fontSize.ts
@@ -1,11 +1,11 @@
-export interface fontSizes {
+export interface fontSizeType {
   default: string
   large: string
   medium: string
   small: string
 }
 
-export const fontSizes = {
+export const fontSizes: fontSizeType = {
   default: '16px',
   large: '36px',
   medium: '20px',

--- a/src/styles/constants/fontSize.ts
+++ b/src/styles/constants/fontSize.ts
@@ -1,11 +1,11 @@
-export interface fontSizeType {
+export interface FontSizeType {
   default: string
   large: string
   medium: string
   small: string
 }
 
-export const fontSizes: fontSizeType = {
+export const fontSizes: FontSizeType = {
   default: '16px',
   large: '36px',
   medium: '20px',


### PR DESCRIPTION
# Description
- ThemeProvider 가 타입을 추론할 수 있도록 적용
- style 상수들을 ThemeProvider에 이동 후 적용

## Change
- styled.d.ts 파일을 추가하여 `DefaultTheme`의 타입 추가
- 적용 영상
![타입추론 추가](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/85441226/c9c89fb1-046e-49a5-a326-db61666d93dc)

- 스타일 상수를 ThemeProvider에 모두 이동시켜, 다음과 같은 형태로 스타일 불러오도록 수정
`color: ${({ theme }) => theme.colors.textColor};`