### PR TITLE
fix: loadMoreBox 노출 조건 수정

### DIFF
--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -45,7 +45,7 @@ export default function IssuesPage() {
         adInterval={5}
       />
       {isLoading && <Loading />}
-      {!isPageEnd && !isLoading && <S.LoadMoreBox ref={loadMoreRef}></S.LoadMoreBox>}
+      {!isPageEnd && !isLoading && !isError && <S.LoadMoreBox ref={loadMoreRef}></S.LoadMoreBox>}
     </S.Wrapper>
   )
 }


### PR DESCRIPTION
### Description
이슈 리스트 무한스크롤을 위한 loadMoreBox 가 에러컴포넌트 노출 시에도 함께 노출되어
예상하지 않은 무한스크롤 발생 버그

### Changes
loadMoreBox 컴포넌트 노출 조건에 (!isErorr) 추가하여 옵저버 동작하지 않도록 했습니다