### PR TITLE
style: #40 이슈리스트 에러 스타일 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.10.1",
         "react-markdown": "^8.0.7",
         "react-router-dom": "^6.15.0",
         "react-scripts": "5.0.1",
@@ -16511,6 +16512,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
+      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.10.1",
     "react-markdown": "^8.0.7",
     "react-router-dom": "^6.15.0",
     "react-scripts": "5.0.1",

--- a/src/components/Issues/IssueListError.tsx
+++ b/src/components/Issues/IssueListError.tsx
@@ -1,11 +1,24 @@
-import { styled } from 'styled-components'
+import { AiOutlineClose } from 'react-icons/ai'
+
+import { useIssueListContext } from '../../hooks/useIssueListContext'
+
+import * as S from './Issues.styled'
 
 function IssueListError() {
-  return <Wrapper>Issue List Get Error! Please check owner and repo</Wrapper>
-}
+  const { setIsError } = useIssueListContext()
 
-const Wrapper = styled.div`
-  margin: 20px 0;
-`
+  return (
+    <S.ErrorWrapper>
+      <S.CloseButton onClick={() => setIsError(false)}>
+        <AiOutlineClose></AiOutlineClose>
+      </S.CloseButton>
+      <p>
+        Issue List Get Error!
+        <br />
+        Please check owner and repo
+      </p>
+    </S.ErrorWrapper>
+  )
+}
 
 export default IssueListError

--- a/src/components/Issues/Issues.styled.ts
+++ b/src/components/Issues/Issues.styled.ts
@@ -78,6 +78,28 @@ export const loadingWrapper = styled.div`
   padding: 20px;
   font-weight: bold;
 `
+export const ErrorWrapper = styled.div`
+  ${({ theme }) => theme.flex.flexCenter};
+  background-color: ${({ theme }) => theme.colors.dimmed};
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  left: 0;
+  top: 0;
+  padding: 20px;
+  color: ${({ theme }) => theme.colors.red};
+  font-size: ${({ theme }) => theme.fontSizes.medium};
+  font-weight: bold;
+`
+export const CloseButton = styled.button`
+  color: ${({ theme }) => theme.colors.white};
+  font-size: 30px;
+  position: absolute;
+  right: 40px;
+  top: 20px;
+  background-color: transparent;
+  cursor: pointer;
+`
 export const LoadMoreBox = styled.div`
   visibility: hidden;
 `

--- a/src/components/Issues/Issues.styled.ts
+++ b/src/components/Issues/Issues.styled.ts
@@ -87,9 +87,11 @@ export const ErrorWrapper = styled.div`
   left: 0;
   top: 0;
   padding: 20px;
+  text-align: center;
+  line-height: 1.6em;
   color: ${({ theme }) => theme.colors.red};
   font-size: ${({ theme }) => theme.fontSizes.medium};
-  font-weight: bold;
+  font-weight: 500;
 `
 export const CloseButton = styled.button`
   color: ${({ theme }) => theme.colors.white};


### PR DESCRIPTION
# Description
- 이슈리스트 에러시 UI 스타일 적용

## Changes
- 에러시 다음과 같은 팝업 형태로, 에러를 인지 가능합니다
![image](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/85441226/9c6a667a-0728-46a3-8fe1-8f275fd31429)


--- 메세지 수정
![image](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/85441226/ce8387c6-a63a-4b6a-b403-d908bb6395d7)


- 닫기 버튼 클릭시, 이전의 화면으로 그대로 돌아갑니다.
- 닫기 구현시에는, `UseIssues.tsx`의  `setIsError` 를 사용했습니다
![image](https://github.com/wanted-pre-onboarding-team-12th-7/pre-onboarding-12th-2-7/assets/85441226/11abebe1-4f07-48bf-af4e-b7ef73048f99)
